### PR TITLE
add build command for maven-like local installation (for testing purposes)

### DIFF
--- a/build/build.clj
+++ b/build/build.clj
@@ -26,3 +26,8 @@
       (dd/deploy {:installer :remote
                   :artifact  jar-file
                   :pom-file  (b/pom-path {:lib lib :class-dir class-dir})}))
+
+(defn install [_]
+  (dd/deploy {:installer :local
+              :artifact  jar-file
+              :pom-file  (b/pom-path {:lib lib :class-dir class-dir})}))


### PR DESCRIPTION
I used this additional command to build locally and install to the local mvn repository `~/.m2/repository`, so I can build and test my projects on unreleased `happyapi.google` versions like

```
clj -T:dev:build build/jar
clj -T:dev:build build/install
```

cf. [the same PR for `happyapi`](https://github.com/timothypratley/happyapi/pull/12)
